### PR TITLE
adding telegram integration

### DIFF
--- a/cmd/timeliner/main.go
+++ b/cmd/timeliner/main.go
@@ -20,6 +20,7 @@ import (
 	_ "github.com/mholt/timeliner/datasources/googlelocation"
 	_ "github.com/mholt/timeliner/datasources/googlephotos"
 	_ "github.com/mholt/timeliner/datasources/instagram"
+	_ "github.com/mholt/timeliner/datasources/telegram"
 	"github.com/mholt/timeliner/datasources/twitter"
 )
 

--- a/datasources/telegram/models.go
+++ b/datasources/telegram/models.go
@@ -1,0 +1,243 @@
+package telegram
+
+import (
+	"encoding/json"
+	"github.com/mholt/timeliner"
+	"hash/fnv"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type telegramArchive struct {
+	Profile       telegramProfile       `json:"personal_information"`
+	ChatContainer telegramChatContainer `json:"chats"`
+}
+
+type telegramChatContainer struct {
+	Chats []telegramChat `json:"list"`
+}
+
+type telegramProfile struct {
+	UserID      int    `json:"user_id"`
+	FirstName   string `json:"first_name"`
+	LastName    string `json:"last_name"`
+	PhoneNumber string `json:"phone_number				"`
+	Username    string `json:"username"`
+}
+
+func (item telegramChat) ID() string {
+	return strconv.Itoa(item.ChatID)
+}
+
+func (item telegramChat) Class() timeliner.ItemClass {
+	return timeliner.CLassConversation
+}
+
+//  ------------------------------- Telegram Chat ---------------------------------------------------------
+
+type telegramChat struct {
+	ChatID   int               `json:"id"`
+	Name     string            `json:"name"`
+	ChatType string            `json:"type"`
+	Messages []telegramMessage `json:"messages"`
+
+	ownerID          string
+	ownerName        string
+	firstMessageTime time.Time
+}
+
+func (item telegramChat) Timestamp() time.Time {
+	return item.firstMessageTime
+}
+
+func (item telegramChat) Owner() (id *string, name *string) {
+	return &item.ownerID, &item.ownerName
+}
+
+func (item telegramChat) DataText() (*string, error) {
+	return nil, nil
+}
+
+func (item telegramChat) DataFileName() *string {
+	return nil
+}
+
+func (item telegramChat) DataFileReader() (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (item telegramChat) DataFileHash() []byte {
+	return nil
+}
+
+func (item telegramChat) DataFileMIMEType() *string {
+	return nil
+}
+
+func (item telegramChat) Metadata() (*timeliner.Metadata, error) {
+	return nil, nil
+}
+
+func (item telegramChat) Location() (*timeliner.Location, error) {
+	return nil, nil
+}
+
+//  ------------------------------- Telegram Message ---------------------------------------------------------
+
+type telegramMessage struct {
+	MessageID           int                         `json:"id"`
+	Date                string                      `json:"date"`
+	Edited              string                      `json:"edited"`
+	From_id             int                         `json:"from_id"`
+	From                string                      `json:"from"`
+	Text                telegramMessageText         `json:"text,omitempty"`
+	MediaType           string                      `json:"media_type,omitempty"`
+	FileRaw             string                      `json:"file,omitempty"`
+	Thumbnail           string                      `json:"thumbnail,omitempty"`
+	Width               int                         `json:"width,omitempty"`
+	Height              int                         `json:"height,omitempty"`
+	PhotoRaw            string                      `json:"photo,omitempty"`
+	MimeType            string                      `json:"mime_type,omitempty"`
+	ViaBot              string                      `json:"via_bot,omitempty"`
+	DurationSeconds     int                         `json:"duration_seconds,omitempty"`
+	LocationInformation telegramLocationInformation `json:"location_information,omitempty"`
+
+	AbsFilePath    string
+	FromIDParsed   string
+	DateParsed     time.Time
+	EditedParsed   time.Time
+	ConversationID string
+}
+
+type telegramComplexMessageContent struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type telegramLocationInformation struct {
+	Latitude  float64 `json:"latitude"`
+	Longitude float64 `json:"longitude"`
+}
+
+type telegramMessageText string
+
+// the text attribute is sometimes just a string and sometimes an array of strings or objects, that themselves contain a text and type attribute
+// this type either returns the string or concatenates all strings and object's text attributes into a string
+func (raw *telegramMessageText) UnmarshalJSON(b []byte) error {
+	// return the string, if it is a string
+	if b[0] == '"' {
+		return json.Unmarshal(b, (*string)(raw))
+	}
+
+	contents := []json.RawMessage{}
+
+	err := json.Unmarshal(b, &contents)
+	if err != nil {
+		panic(err)
+	}
+
+	// loop through list and concatenate the unmarshalled strings
+	var str strings.Builder
+
+	for _, c := range contents {
+		if c[0] == '"' {
+			// parsing string object directly
+			var s string
+			err := json.Unmarshal(c, (*string)(&s))
+
+			if err != nil {
+				panic(err)
+			}
+
+			str.WriteString(s)
+
+		} else {
+			// parsing a json object's text attribute and ignoring the rest
+			var m telegramComplexMessageContent
+			err := json.Unmarshal(c, (*telegramComplexMessageContent)(&m))
+
+			if err != nil {
+				panic(err)
+			}
+			str.WriteString(m.Text)
+		}
+	}
+
+	*raw = telegramMessageText(str.String())
+
+	return nil
+}
+
+func (item telegramMessage) ID() string {
+	return strconv.Itoa(item.MessageID)
+}
+
+func (item telegramMessage) Timestamp() time.Time {
+	return item.DateParsed
+}
+
+func (item telegramMessage) Class() timeliner.ItemClass {
+	return timeliner.ClassPrivateMessage
+}
+
+func (item telegramMessage) Owner() (id *string, name *string) {
+	return &item.FromIDParsed, &item.From
+}
+
+func (item telegramMessage) DataText() (*string, error) {
+	return (*string)(&item.Text), nil
+}
+
+func (item telegramMessage) DataFileName() *string {
+	// Making filenames "more unique" here by prepending a hash based on the conversation id and the timestamp to the filename
+	// This hopefully avoids naming collisions and overwritten files during the import
+	// (e.g. redundant names like "giphy.mp4" or "sticker.webp" are actually different files with identical names...
+
+	var fpathname, rawfname = filepath.Split(item.AbsFilePath)
+
+	h := fnv.New32a()
+	_, _ = h.Write([]byte(item.Date + item.ConversationID))
+	uid := strconv.FormatUint(uint64(h.Sum32()), 10)
+
+	item.AbsFilePath = filepath.Join(fpathname, uid+"-"+rawfname)
+
+	fname := filepath.Base(item.AbsFilePath)
+	return &fname
+}
+
+func (item telegramMessage) DataFileReader() (io.ReadCloser, error) {
+	if item.AbsFilePath == "" {
+		return nil, nil
+	} else {
+		f, err := os.Open(item.AbsFilePath)
+		return f, err
+	}
+}
+
+func (item telegramMessage) DataFileHash() []byte {
+	return nil
+}
+
+func (item telegramMessage) DataFileMIMEType() *string {
+	return &item.MimeType
+}
+
+func (item telegramMessage) Metadata() (*timeliner.Metadata, error) {
+	return &timeliner.Metadata{
+		EditedDate: item.EditedParsed,
+		MediaType:  item.MediaType,
+		Width:      item.Width,
+		Height:     item.Height,
+	}, nil
+}
+
+func (item telegramMessage) Location() (*timeliner.Location, error) {
+	return &timeliner.Location{
+		&item.LocationInformation.Latitude,
+		&item.LocationInformation.Longitude,
+	}, nil
+}

--- a/datasources/telegram/telegram.go
+++ b/datasources/telegram/telegram.go
@@ -1,0 +1,152 @@
+// Package telegram implements a Timeliner data source for the Telegram messenger. (TODO)
+package telegram
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/mholt/timeliner"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+const (
+	DataSourceName = "Telegram" // TODO: brand name
+	DataSourceID   = "telegram" // TODO: snake_cased unique name
+)
+
+var dataSource = timeliner.DataSource{
+	ID:   DataSourceID,
+	Name: DataSourceName,
+	NewClient: func(acc timeliner.Account) (timeliner.Client, error) {
+		return new(Client), nil
+	},
+}
+
+func init() {
+	err := timeliner.RegisterDataSource(dataSource)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+const tgTimeFormat = "2006-01-02T15:04:05"
+
+func tgTimeToGoTime(tgTime string, location *time.Location) time.Time {
+	if tgTime == "" {
+		return time.Time{}
+	}
+	ts, err := time.ParseInLocation(tgTimeFormat, tgTime, location)
+	if err != nil {
+		log.Printf("[ERROR] Parsing timestamp from Telegram: '%s' is not in '%s' format",
+			tgTime, tgTimeFormat)
+	}
+	return ts
+}
+
+// Client implements the timeliner.Client interface.
+type Client struct{}
+
+// ListItems lists items from the data source.
+func (c *Client) ListItems(ctx context.Context, itemChan chan<- *timeliner.ItemGraph, opt timeliner.Options) error {
+	defer close(itemChan)
+
+	if opt.Filename == "" {
+		return fmt.Errorf("filename is required")
+	}
+
+	//TODO: make the default timezone location a command line argument
+	loc, _ := time.LoadLocation("Europe/Berlin")
+	//if opt.Timezone == "" {
+	//	return fmt.Errorf("timezone is required")
+	//}
+
+	//loc, err := time.LoadLocation(opt.Timezone)
+	//if err != nil {
+	//	return fmt.Errorf("invalid timezone argument: '%v'", err)
+	//}
+
+	file, err := os.Open(opt.Filename)
+	if err != nil {
+		return fmt.Errorf("opening data file: %v", err)
+	}
+
+	datadir := filepath.Dir(opt.Filename)
+
+	defer file.Close()
+
+	dec := json.NewDecoder(file)
+
+	var prev *telegramArchive
+	for dec.More() {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			var err error
+			prev, err = c.processTelegramArchive(dec, prev, itemChan)
+			if err != nil {
+				return fmt.Errorf("processing telegramArchive item: %v", err)
+			}
+
+			var collectionDescription = "Telegram Chat"
+
+			for idc, _ := range prev.ChatContainer.Chats {
+				chat := &prev.ChatContainer.Chats[idc];
+				if len(chat.Messages) == 0 {
+					continue
+				}
+
+				chat.ownerID = strconv.Itoa(prev.Profile.UserID)
+				//TODO: Telegram offers optional attributes for First Name, Last Name and a Username. Decide/Concatenate!
+				chat.ownerName = prev.Profile.FirstName + prev.Profile.LastName + "(" + prev.Profile.Username + ")"
+				chat.firstMessageTime = tgTimeToGoTime(chat.Messages[0].Date, loc)
+
+				var ig = timeliner.NewItemGraph(chat)
+
+				col := timeliner.Collection{
+					OriginalID:  chat.ID(),
+					Name:        &chat.Name,
+					Description: &collectionDescription,
+				}
+
+				for midx, message := range chat.Messages {
+					message.FromIDParsed = strconv.Itoa(message.From_id)
+					message.DateParsed = tgTimeToGoTime(message.Date, loc)
+					message.EditedParsed = tgTimeToGoTime(message.Edited, loc)
+					message.ConversationID = chat.ID()
+
+					if message.FileRaw != "" {
+						message.AbsFilePath = filepath.Join(datadir, message.FileRaw)
+					} else if message.PhotoRaw != "" {
+						message.AbsFilePath = filepath.Join(datadir, message.PhotoRaw)
+					}
+
+					col.Items = append(col.Items, timeliner.CollectionItem{
+						Position: midx,
+						Item:     message,
+					})
+				}
+
+				ig.Collections = append(ig.Collections, col)
+				itemChan <- ig
+			}
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) processTelegramArchive(dec *json.Decoder, prev *telegramArchive,
+	itemChan chan<- *timeliner.ItemGraph) (*telegramArchive, error) {
+
+	var l *telegramArchive
+	err := dec.Decode(&l)
+	if err != nil {
+		return nil, fmt.Errorf("decoding telegramArchive: %v", err)
+	}
+	return l, nil
+}

--- a/itemgraph.go
+++ b/itemgraph.go
@@ -141,6 +141,7 @@ const (
 	ClassLocation
 	ClassEmail
 	ClassPrivateMessage
+	CLassConversation
 )
 
 // These are the standard relationships that Timeliner
@@ -392,6 +393,10 @@ type Metadata struct {
 
 	Shares int // aka "Retweets" or "Reshares"
 	Likes  int
+
+	// Messages (Telegram)
+	EditedDate time.Time
+	MediaType  string
 }
 
 func (m *Metadata) encode() ([]byte, error) {

--- a/timeliner.go
+++ b/timeliner.go
@@ -94,6 +94,12 @@ type Options struct {
 	// A checkpoint from which to resume
 	// item retrieval.
 	Checkpoint []byte
+
+	//TODO: Integrate a new timezone parameter for telegram
+	// A default timezone to use for timestamps
+	// without explicit timezones, e.g. "Europe/Berlin"
+	// See https://golang.org/pkg/time/#LoadLocation
+	//Timezone string
 }
 
 // FakeCloser turns an io.Reader into an io.ReadCloser


### PR DESCRIPTION
Hi, here is a draft for integrating the telegram data export into timeliner (issue #17).

There are a couple of things that would need to be sorted out before merging the pull request. 

1. The telegram archive contains a lot of files that potentially have the same name (e.g. "giphy.mp4" or "sticker.webp"). I tried to circumvent the issue of overwritten files by prepending a hash of the timestamp and conversation id to the filename, but still, I can see some errors during the import and some files seem to be missing. Do you have any ideas? Here is the error message:
``[ERROR] Processing item graph: processing collection: adding item from collection to storage: replacing data file with identical existing file: removing duplicate data file: remove timeliner_repo\data\2018\04\telegram\2505156913-video9.mp4: The process cannot access the file because it is being used by another process.``

2. The datetime strings in this data source do not have any timezone information. Therefore I would suggest to add a custom parameter for the default timezone. See ``line 61`` onwards in ``telegram.go``