### PR TITLE
Show link to the auth page even if we couldn't open a browser.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 _gitignore/
 _storage/
 oauth2client/oauth2proxy/cmd/oauth2proxy/credentials.toml
-cmd/timeliner/timeliner.toml
+**/timeliner.toml
 cmc/timeliner/timeliner

--- a/oauth2client/browser.go
+++ b/oauth2client/browser.go
@@ -73,7 +73,7 @@ func (b Browser) Get(expectedStateVal, authCodeURL string) (string, error) {
 
 	err = openBrowser(authCodeURL)
 	if err != nil {
-		fmt.Printf("Can't open browser (%s). Please follow the link: %s", err, authCodeURL)
+		fmt.Printf("Can't open browser: %s.\nPlease follow this link: %s", err, authCodeURL)
 	}
 
 	select {

--- a/oauth2client/browser.go
+++ b/oauth2client/browser.go
@@ -73,7 +73,7 @@ func (b Browser) Get(expectedStateVal, authCodeURL string) (string, error) {
 
 	err = openBrowser(authCodeURL)
 	if err != nil {
-		return "", err
+		fmt.Printf("Can't open browser (%s). Please follow the link: %s", err, authCodeURL)
 	}
 
 	select {


### PR DESCRIPTION
In case if we couldn't open a browser using `xdg-open` (For
example xdg-utils can be not installed in the system) -- user will still able to
follow the link (copy-paste from the terminal) and obtain oauth code.

Message will look like this:
```
Can't open browser (exec: "xdg-open": executable file not found in $PATH: ). Please follow the link: https://accounts.google.com/o/oauth2
```