### PR TITLE
Remove gmail datasource that seems to have been accidentally added

### DIFF
--- a/cmd/timeliner/main.go
+++ b/cmd/timeliner/main.go
@@ -17,7 +17,6 @@ import (
 
 	// plug in data sources
 	_ "github.com/mholt/timeliner/datasources/facebook"
-	_ "github.com/mholt/timeliner/datasources/gmail"
 	_ "github.com/mholt/timeliner/datasources/googlelocation"
 	_ "github.com/mholt/timeliner/datasources/googlephotos"
 	_ "github.com/mholt/timeliner/datasources/instagram"


### PR DESCRIPTION
Added in https://github.com/mholt/timeliner/commit/a8c45a803def7e68805f2d205232e9026bf9003e\#diff-546a80e82a79b4c124d58e0f3f6e9f6cc1def1ec55431c7d2de5b844ab7388c7R20

Otherwise, I ran into the following error message locally
```
go: finding module for package github.com/mholt/timeliner/datasources/gmail
main.go:20:2: no matching versions for query "latest"